### PR TITLE
Deprecate the tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # DNSimple Punktum DS upload
 
+> [!IMPORTANT]
+> Deprecated: Punktum.dk has closed the DS-update Service, see
+> <https://punktum.dk/artikler/breaking-changes>
+
 [![Go reference](https://pkg.go.dev/badge/github.com/reload/dnsimple-punktum-dk-ds-upload)](https://pkg.go.dev/github.com/reload/dnsimple-punktum-dk-ds-upload)
 
 Package function is a Google Cloud Function receiving webhook events

--- a/README.md.template
+++ b/README.md.template
@@ -1,5 +1,9 @@
 # DNSimple Punktum DS upload
 
+> [!IMPORTANT]
+> Deprecated: Punktum.dk has closed the DS-update Service, see
+> <https://punktum.dk/artikler/breaking-changes>
+
 [![Go reference](https://pkg.go.dev/badge/github.com/reload/dnsimple-punktum-dk-ds-upload)](https://pkg.go.dev/github.com/reload/dnsimple-punktum-dk-ds-upload)
 
 {{ .Doc }}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Punktum.dk has closed the DS-update Service, see https://punktum.dk/artikler/breaking-changes
 module github.com/reload/dnsimple-punktum-dk-ds-upload
 
 require (


### PR DESCRIPTION
Punktum.dk has closed the DS-update Service.

See https://punktum.dk/artikler/breaking-changes
